### PR TITLE
Fix path handling for dynamic environment

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,12 +10,12 @@ from dotenv import load_dotenv
 from watchdog.observers import Observer
 from scripts.plot_event_handler import PlotFileEventHandler
 
-# Hardcoded paths
-PLOT_SCRIPTS_DIR = os.path.join(os.getcwd(), 'scripts', 'plots')
-OUTPUT_PLOTS_DIR = os.path.join(os.getcwd(), 'output', 'plots')
+# Determine project root based on this file's location
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-# Set the working directory to the project root
-os.chdir('/workspaces/python/intervals_graph')
+# Paths to the directories used throughout the app
+PLOT_SCRIPTS_DIR = os.path.join(BASE_DIR, 'scripts', 'plots')
+OUTPUT_PLOTS_DIR = os.path.join(BASE_DIR, 'output', 'plots')
 
 def start_file_observer(df):
     """Start the watchdog observer to monitor plot scripts."""

--- a/scripts/plot_event_handler.py
+++ b/scripts/plot_event_handler.py
@@ -2,8 +2,11 @@ import os
 from watchdog.events import FileSystemEventHandler
 from scripts.plot_manager import generate_main_html_report, load_and_run_plot_script
 
-# Use the correct directories
-PLOT_SCRIPTS_DIR = os.path.join(os.getcwd(), 'scripts', 'plots')
+# Determine project root relative to this file
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Directory where plot scripts live
+PLOT_SCRIPTS_DIR = os.path.join(BASE_DIR, 'scripts', 'plots')
 
 class PlotFileEventHandler(FileSystemEventHandler):
     """Handle creation, modification, and deletion of plot files."""

--- a/scripts/plot_manager.py
+++ b/scripts/plot_manager.py
@@ -1,9 +1,12 @@
 import os
 import importlib.util
 
-# Use the correct directories
-PLOT_SCRIPTS_DIR = os.path.join(os.getcwd(), 'scripts', 'plots')
-OUTPUT_PLOTS_DIR = os.path.join(os.getcwd(), 'output', 'plots')
+# Determine project root relative to this file
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Directories used for locating and saving plots
+PLOT_SCRIPTS_DIR = os.path.join(BASE_DIR, 'scripts', 'plots')
+OUTPUT_PLOTS_DIR = os.path.join(BASE_DIR, 'output', 'plots')
 
 def load_and_run_plot_script(script_path, df, output_dir):
     try:


### PR DESCRIPTION
## Summary
- fix hardcoded project paths in `main.py`
- compute project root consistently in helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6858ffee9f18832ca4f7963d19235bd3